### PR TITLE
Fixed links not working properly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terabit_desktop",
-  "productName": "Terabit Desktop",
+  "productName": "TerabitDesktop",
   "version": "1.0.0",
   "description": "Terabit Hosting Management Panel for Desktop.",
   "main": "./src/out/tbsdk/main.js",

--- a/src/ui/WindowManagment.ts
+++ b/src/ui/WindowManagment.ts
@@ -59,15 +59,10 @@ const domains = [
 ];
 
 function GetHardCodedUrl(): string {
-    const args = process.argv.slice(2);
+    const args = process.argv;
     const url = args.find(arg => domains.some(domain => arg.startsWith(domain))) || 'https://gaming.terabit.io/';
-    
     if (url.startsWith('terabit://my')) {
         return 'https://my.terabit.io/'
-    }
-    if (url.startsWith('terabit://')) {
-        const path = url.replace('terabit://', '');
-        return `https://gaming.terabit.io/${path}`;
     }
     if (url.startsWith('terabit://dcs')) {
         const path = url.replace("terabit://dcs", '');
@@ -77,6 +72,11 @@ function GetHardCodedUrl(): string {
         const path = url.replace('terabit://vps', '');
         return `https://vps.terabit.io/${path}`;
     }
+    if (url.startsWith('terabit://')) {
+        const path = url.replace('terabit://', '');
+        return `https://gaming.terabit.io/${path}`;
+    }
 
+    console.log(`returning ${url}`);
     return url;
 }


### PR DESCRIPTION
Moved the other terabit://xyz protocols above the default terabit:// to allow them to be matched.
Removed the argv.slice() as it was causing the URL to be forced as only the 2nd argument, rather than any argument.